### PR TITLE
decorators: content type header decorator check

### DIFF
--- a/invenio_rest/decorators.py
+++ b/invenio_rest/decorators.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Decorators for testing certain assertions."""
+
+from __future__ import absolute_import, print_function
+
+from functools import wraps
+
+from flask import request
+
+from .errors import InvalidContentType
+
+
+def require_content_types(*allowed_content_types):
+    """Decorator to test if proper content-type is provided."""
+    def decorator(f):
+        @wraps(f)
+        def inner(*args, **kwargs):
+            if request.content_type not in allowed_content_types:
+                raise InvalidContentType(allowed_content_types)
+            return f(*args, **kwargs)
+        return inner
+    return decorator

--- a/invenio_rest/errors.py
+++ b/invenio_rest/errors.py
@@ -24,6 +24,31 @@
 
 """Exceptions used in Invenio REST module."""
 
+from __future__ import absolute_import, print_function
+
+import json
+
+from werkzeug.exceptions import HTTPException
+
+
+class RESTException(HTTPException):
+    """HTTP Exception delivering JSON error responses."""
+
+    def get_description(self, environ=None):
+        """Get the description."""
+        return self.description
+
+    def get_body(self, environ=None):
+        """Get the request body."""
+        return json.dumps(dict(
+            status=self.code,
+            message=self.get_description(environ)
+        ))
+
+    def get_headers(self, environ=None):
+        """Get a list of headers."""
+        return [('Content-Type', 'application/json')]
+
 
 class SameContentException(Exception):
     """304 Same Content exception.
@@ -38,3 +63,16 @@ class SameContentException(Exception):
         :param etag: matching etag
         """
         self.etag = etag
+
+
+class InvalidContentType(RESTException):
+    """Error for when an invalid content-type is provided."""
+
+    code = 415
+
+    def __init__(self, allowed_contet_types=None):
+        """Initialize exception."""
+        self.allowed_contet_types = allowed_contet_types
+        self.description = \
+            "Invalid 'Content-Type' header. Expected one of: {0}".format(
+                ", ".join(allowed_contet_types))

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Module tests."""
+
+from __future__ import absolute_import, print_function
+
+import json
+
+from invenio_rest import InvenioREST
+from invenio_rest.decorators import require_content_types
+
+
+def test_require_content_types(app):
+    """Error handlers view."""
+    InvenioREST(app)
+
+    @app.route("/", methods=['POST'])
+    @require_content_types('application/json', 'text/plain')
+    def test_view():
+        return "OK"
+
+    with app.test_client() as client:
+        res = client.post("/", content_type='application/json', data="{}")
+        assert res.status_code == 200
+        res = client.post("/", content_type='text/plain', data="test")
+        assert res.status_code == 200
+        res = client.post("/", content_type='application/xml', data="<d></d>")
+        assert res.status_code == 415
+        data = json.loads(res.get_data(as_text=True))
+        assert data['status'] == 415
+        assert 'application/json' in data['message']
+        assert 'text/plain' in data['message']

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Error module tests."""
+
+from __future__ import absolute_import, print_function
+
+import json
+
+from invenio_rest import InvenioREST
+from invenio_rest.errors import InvalidContentType, RESTException
+
+
+def test_errors(app):
+    """Error handlers view."""
+    InvenioREST(app)
+
+    @app.route('/', methods=['GET'])
+    def test_rest():
+        raise RESTException(description='error description')
+
+    @app.route('/contenttype', methods=['GET'])
+    def test_content_type():
+        raise InvalidContentType(allowed_contet_types=['application/json'])
+
+    with app.test_client() as client:
+        res = client.get('/')
+        assert res.status_code == 200
+        data = json.loads(res.get_data(as_text=True))
+        assert data['status'] is None
+        assert data['message'] == 'error description'
+
+        res = client.get('/contenttype')
+        assert res.status_code == 415
+        data = json.loads(res.get_data(as_text=True))
+        assert data['status'] == 415
+        assert 'application/json' in data['message']

--- a/tests/test_invenio_rest.py
+++ b/tests/test_invenio_rest.py
@@ -170,7 +170,7 @@ def test_ratelimt(app):
 
 
 def test_content_negotiation_method_view(app):
-    """Test ContentNegotiationMethodView"""
+    """Test ContentNegotiationMethodView."""
     def obj_to_json_serializer(data, code=200, headers=None):
         if data:
             res = jsonify(data)


### PR DESCRIPTION
* Adds decorator to require specific values for Content-Type header in
  views.

* Adds RESTException class for proper REST API JSON error responses.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>