### PR TITLE
views: separate http method serializers support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,6 +37,7 @@ charset = utf-8
 indent_size = 4
 # isort plugin configuration
 known_first_party = invenio_rest
+known_third_party = flask_limiter, flask_cors
 multi_line_output = 2
 default_section = THIRDPARTY
 


### PR DESCRIPTION
* NEW Adds support in ContentNegotiatedMethodView for serializers
  configuration for each http method.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>