### PR TITLE
ext: unprocessable entity addition

### DIFF
--- a/invenio_rest/ext.py
+++ b/invenio_rest/ext.py
@@ -89,6 +89,8 @@ class InvenioREST(object):
             status=412, message='Precondition Failed'))
         app.errorhandler(415)(create_api_errorhandler(
             status=415, message='Unsupported media type'))
+        app.errorhandler(422)(create_api_errorhandler(
+            status=422, message='Unprocessable Entity'))
         app.errorhandler(429)(create_api_errorhandler(
             status=429, message='Rate limit exceeded'))
         app.errorhandler(500)(create_api_errorhandler(

--- a/tests/test_invenio_rest.py
+++ b/tests/test_invenio_rest.py
@@ -71,8 +71,8 @@ def test_error_handlers(app):
         abort(status_code)
 
     error_codes = [
-        400, 401, 403, 404, 405, 406, 409, 410, 412, 415, 429, 500, 501, 502,
-        503, 504]
+        400, 401, 403, 404, 405, 406, 409, 410, 412, 422, 415, 429, 500, 501,
+        502, 503, 504]
 
     with app.test_client() as client:
         verbs = [client.get, client.post, client.put, client.delete,


### PR DESCRIPTION
* Adds "Unprocessable Entity" (422) to list of HTTP errors with JSON
  response.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>