### PR TITLE
decorators: fix content type check

### DIFF
--- a/invenio_rest/decorators.py
+++ b/invenio_rest/decorators.py
@@ -43,7 +43,7 @@ def require_content_types(*allowed_content_types):
     def decorator(f):
         @wraps(f)
         def inner(*args, **kwargs):
-            if request.content_type not in allowed_content_types:
+            if request.mimetype not in allowed_content_types:
                 raise InvalidContentType(allowed_content_types)
             return f(*args, **kwargs)
         return inner

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -46,6 +46,9 @@ def test_require_content_types(app):
         assert res.status_code == 200
         res = client.post("/", content_type='text/plain', data="test")
         assert res.status_code == 200
+        res = client.post("/", content_type='application/json;charset=utf-8',
+                          data="{}")
+        assert res.status_code == 200
         res = client.post("/", content_type='application/xml', data="<d></d>")
         assert res.status_code == 415
         data = json.loads(res.get_data(as_text=True))


### PR DESCRIPTION
* Uses the request mimetype instead of raw content type header.
  (addresses inveniosoftware/invenio-records-rest#118)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>