### PR TITLE
tests: simplify doctest execution

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,10 @@ author = u'CERN'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', 'invenio_rest', 'version.py'), 'rt') as fp:
+with open(os.path.join(os.path.dirname(__file__),
+                       '..',
+                       'invenio_rest',
+                       'version.py'), 'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -23,4 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=invenio_rest --cov-report=term-missing
+pep8ignore = docs/conf.py ALL
+addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_rest --cov-report=term-missing docs tests invenio_rest
+doctest_optionflags = DONT_ACCEPT_TRUE_FOR_1 ELLIPSIS IGNORE_EXCEPTION_DETAIL

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,5 +27,4 @@ pydocstyle invenio_rest tests docs && \
 isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test


### PR DESCRIPTION
* doctests are now executed with pytest instead of sphinx.
  ( closes #65 )

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>