### PR TITLE
config: limiter configuration update

### DIFF
--- a/invenio_rest/config.py
+++ b/invenio_rest/config.py
@@ -72,8 +72,8 @@ CORS_EXPOSE_HEADERS = [
 REST_ENABLE_CORS = False
 """Enable CORS configuration. (Default: ``False``)"""
 
-RATELIMIT_GLOBAL = '5000/hour'
-"""Global rate limit.
+RATELIMIT_DEFAULT = '5000/hour'
+"""Default rate limit.
 
 .. note:: Overwrite
    Flask-Limiter <https://flask-limiter.readthedocs.io/en/stable/>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,6 @@ all_files = 1
 
 [bdist_wheel]
 universal = 1
+
+[pydocstyle]
+add_ignore = D401

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.11.1',
-    'Flask-Limiter>=0.8.5',
+    'Flask-Limiter>=0.9.4',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Ignores pydocstyle error code D401 ("First line should be in
imperative mood") as the parsing and detection is pretty broken.
(addresses inveniosoftware/troubleshooting#9)

Uses `RATELIMIT_DEFAULT` instead of `RATELIMIT_GLOBAL`, deprecated
in version `0.9.4`, to prevent a warning when instantiating an app.