### PR TITLE
global: addition of secure HTTP headers

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -58,7 +58,8 @@ The example app demonstrates:
   ``Access-Control-Expose-Headers``).
 * Rate limiting (the example app allows 5 requests per minute) and associated
   headers ``X-RateLimit-Limit``, ``X-RateLimit-Remaining``,
-  ``X-RateLimit-Reset``, ``Retry-After``,
+  ``X-RateLimit-Reset``, ``Retry-After``.
+* Secure HTTP response headers.
 
 To reset the example application run:
 

--- a/invenio_rest/config.py
+++ b/invenio_rest/config.py
@@ -87,3 +87,52 @@ RATELIMIT_HEADERS_ENABLED = True
    Flask-Limiter <https://flask-limiter.readthedocs.io/en/stable/>`_
    configuration.
 """
+
+REST_ENABLE_SECURE_HEADERS = True
+"""Enable Secure Headers. (Default: ``True``)
+
+For development you can set ```REST_ENABLE_SECURE_HEADERS = False ```
+
+.. note::
+    `W3C
+    <https://www.w3.org/TR/CSP2/>`_
+"""
+
+REST_DEFAULT_SECURE_HEADERS = {
+    'force_https': False,
+    'force_https_permanent': False,
+    'force_file_save': False,
+    'frame_options': 'sameorigin',
+    'frame_options_allow_from': None,
+    'strict_transport_security': True,
+    'strict_transport_security_preload': False,
+    'strict_transport_security_max_age': 31556926,  # One year in seconds
+    'strict_transport_security_include_subdomains': True,
+    'content_security_policy': {
+        'default-src': '\'self\'',
+    },
+    'content_security_policy_report_uri': None,
+    'content_security_policy_report_only': False,
+    'session_cookie_secure': True,
+    'session_cookie_http_only': True
+}
+"""Default Secure Headers.
+
+.. note:: Overwrite
+    `Flask-Talisman
+    <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_talisman import Talisman
+
+    app = Flask(__name__)
+    talisman = Talisman(app)
+
+    @app.route('/defenders')
+    @talisman(frame_options_allow_from='*')
+    def defenders():
+        \"\"\"Override policies for the specific view.\"\"\"
+        return 'Jessica Jones'
+"""

--- a/invenio_rest/ext.py
+++ b/invenio_rest/ext.py
@@ -66,6 +66,17 @@ class InvenioREST(object):
                 raise RuntimeError(
                     'You must use `pip install invenio-rest[cors]` to '
                     'enable CORS support.')
+        # Enable secure HTTP headers
+        if app.config['REST_ENABLE_SECURE_HEADERS']:
+            try:
+                pkg_resources.get_distribution('Flask-Talisman')
+                from flask_talisman import Talisman
+                Talisman(app, **app.config.get('REST_DEFAULT_SECURE_HEADERS',
+                                               {}))
+            except pkg_resources.DistributionNotFound:
+                raise RuntimeError(
+                    'You must use `pip install invenio-rest[secureheaders]` to'
+                    ' enable Secure Headers support.')
 
         self.limiter = Limiter(app, key_func=get_ipaddr)
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ extras_require = {
     'cors': [
         'Flask-CORS>=2.1.0',
     ],
+    'secureheaders': [
+        'Flask-Talisman>=0.3.2',
+    ],
     'docs': [
         'Sphinx>=1.4.2',
     ],

--- a/tests/test_invenio_rest.py
+++ b/tests/test_invenio_rest.py
@@ -175,6 +175,44 @@ def test_ratelimt(app):
         assert res.headers['X-RateLimit-Reset']
 
 
+def test_secure_headers(app):
+    """Test Secure Headers support."""
+    app.config['REST_ENABLE_SECURE_HEADERS'] = True
+
+    InvenioREST(app)
+
+    @app.route('/')
+    def avangers():
+        return 'infinity war'
+
+    with app.test_client() as client:
+        res = client.get('/')
+        assert res.status_code == 200
+        assert res.headers['X-Content-Security-Policy']
+        assert res.headers['X-Content-Type-Options']
+        assert res.headers['X-Frame-Options']
+        assert res.headers['X-XSS-Protection']
+
+
+def test_secure_headers_disabled(app):
+    """Test Secure Headers support."""
+    app.config['REST_ENABLE_SECURE_HEADERS'] = False
+
+    InvenioREST(app)
+
+    @app.route('/')
+    def avangers():
+        return 'infinity war'
+
+    with app.test_client() as client:
+        res = client.get('/')
+        assert res.status_code == 200
+        assert not res.headers.get('X-Content-Security-Policy', False)
+        assert not res.headers.get('X-Content-Type-Options', False)
+        assert not res.headers.get('X-Frame-Options', False)
+        assert not res.headers.get('X-XSS-Protection', False)
+
+
 def _obj_to_json_serializer(data, code=200, headers=None):
     if data:
         res = jsonify(data)


### PR DESCRIPTION
* Adds the option to enable ``REST_ENABLE_SECURE_HEADERS`` for HTTP
  requests. (closes #25)

Signed-off-by: Harris Tzovanakis <me@drjova.com>