### PR TITLE
global: sentry event ID in reponse

### DIFF
--- a/invenio_rest/errors.py
+++ b/invenio_rest/errors.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 import json
 
+from flask import g
 from werkzeug.exceptions import HTTPException
 from werkzeug.http import http_date
 
@@ -90,6 +91,9 @@ class RESTException(HTTPException):
         errors = self.get_errors()
         if self.errors:
             body['errors'] = errors
+
+        if self.code and (self.code >= 500) and hasattr(g, 'sentry_event_id'):
+            body['error_id'] = str(g.sentry_event_id)
 
         return json.dumps(body)
 

--- a/invenio_rest/views.py
+++ b/invenio_rest/views.py
@@ -26,7 +26,8 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import Response, abort, current_app, jsonify, make_response, request
+from flask import Response, abort, current_app, g, jsonify, make_response, \
+    request
 from flask.views import MethodView
 from werkzeug.exceptions import HTTPException
 
@@ -51,6 +52,8 @@ def create_api_errorhandler(**kwargs):
             return e.get_response()
         elif isinstance(e, HTTPException) and e.description:
             kwargs['message'] = e.description
+        if kwargs.get('status', 400) >= 500 and hasattr(g, 'sentry_event_id'):
+            kwargs['error_id'] = str(g.sentry_event_id)
         return make_response(jsonify(kwargs), kwargs['status'])
     return api_errorhandler
 


### PR DESCRIPTION
* Adds the Sentry Event ID in the payload of REST exception responses.
  (closes #76)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>