### PR TITLE
cors: move CORS dependency from extra to install

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,11 +6,3 @@ Invenio-REST is on PyPI so all you need is:
 .. code-block:: console
 
    $ pip install invenio-rest
-
-If you want Cross-Origin Resource Sharing (CORS) support you need to either
-install Flask-CORS manually or simply use the extra requires directive like
-this:
-
-.. code-block:: console
-
-   $ pip install invenio-rest[cors]

--- a/invenio_rest/ext.py
+++ b/invenio_rest/ext.py
@@ -54,15 +54,9 @@ class InvenioREST(object):
 
         # Enable CORS support if desired
         if app.config['REST_ENABLE_CORS']:
-            try:
-                pkg_resources.get_distribution('Flask-CORS')
-                from flask_cors import CORS
-                CORS(app)
-                # CORS can be configured using CORS_* configuration variables.
-            except pkg_resources.DistributionNotFound:
-                raise RuntimeError(
-                    'You must use `pip install invenio-rest[cors]` to '
-                    'enable CORS support.')
+            from flask_cors import CORS
+            CORS(app)
+            # CORS can be configured using CORS_* configuration variables.
 
         app.errorhandler(400)(create_api_errorhandler(
             status=400, message='Bad Request'))

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,5 +21,3 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-
--e git+https://github.com/corydolphin/flask-cors.git#egg=Flask-CORS

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,6 @@ tests_require = [
 ]
 
 extras_require = {
-    'cors': [
-        'Flask-CORS>=2.1.0',
-    ],
     'docs': [
         'Sphinx>=1.4.2',
     ],
@@ -66,6 +63,7 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.11.1',
+    'Flask-CORS>=2.1.0'
 ]
 
 packages = find_packages()

--- a/tests/test_invenio_rest.py
+++ b/tests/test_invenio_rest.py
@@ -113,15 +113,6 @@ def test_custom_httpexception(app):
         assert data['status'] == 400
 
 
-def test_cors_loading(app):
-    """Test CORS support."""
-    app.config['REST_ENABLE_CORS'] = True
-
-    with patch('flask_cors.CORS') as CORS:
-        CORS.side_effect = pkg_resources.DistributionNotFound
-        pytest.raises(RuntimeError, InvenioREST, app)
-
-
 def test_cors(app):
     """Test CORS support."""
     app.config['REST_ENABLE_CORS'] = True


### PR DESCRIPTION
After discussion with @lnielsen, CORS dependency will be installed by default (but no change on behaviour, still disabled by default). This will simplify the Invenio+Cookiecutter instance installation.

[ci-skip]