### PR TITLE
docs: Change documentation link for flask to 1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,7 +323,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'Flask': ('http://flask.pocoo.org/docs/0.12', None),
+    'Flask': ('https://flask.palletsprojects.com', None),
     'werkzeug': ('http://werkzeug.pocoo.org/docs/0.14', None),
 }
 


### PR DESCRIPTION
closes #91