### PR TITLE
global: bump webargs version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.1.2 (released 2019-09-19)
+
+- Bumps webargs to 5.5.0 (provides support for marshmallow 3)
+
 Version 1.1.1 (released 2019-08-02)
 
 - Bumps marshmallow to 2.15.2 (minimum required by webargs).

--- a/invenio_rest/version.py
+++ b/invenio_rest/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_requires = [
 install_requires = [
     'Flask>=0.11.1',
     'Flask-CORS>=2.1.0',
-    'webargs>=5.1.3',
+    'webargs>=5.5.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* bumped to provide compatibility for marshmallow 2 and 3 versions