### PR TITLE
Make package ready for Flask 2

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,3 +24,4 @@ Contributors
 - Sami Hiltunen
 - Sebastian Witowski
 - Tibor Simko
+- Maximilian Moser

--- a/invenio_rest/errors.py
+++ b/invenio_rest/errors.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2021      TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -61,11 +62,11 @@ class RESTException(HTTPException):
         """
         return [e.to_dict() for e in self.errors] if self.errors else None
 
-    def get_description(self, environ=None):
+    def get_description(self, environ=None, scope=None):
         """Get the description."""
         return self.description
 
-    def get_body(self, environ=None):
+    def get_body(self, environ=None, scope=None):
         """Get the request body."""
         body = dict(
             status=self.code,
@@ -81,7 +82,7 @@ class RESTException(HTTPException):
 
         return json.dumps(body)
 
-    def get_headers(self, environ=None):
+    def get_headers(self, environ=None, scope=None):
         """Get a list of headers."""
         return [('Content-Type', 'application/json')]
 
@@ -144,7 +145,7 @@ class SameContentException(RESTException):
         self.etag = etag
         self.last_modified = last_modified
 
-    def get_response(self, environ=None):
+    def get_response(self, environ=None, scope=None):
         """Get a list of headers."""
         response = super(SameContentException, self).get_response(
             environ=environ


### PR DESCRIPTION
The werkzeug HTTPException requires a new positional argument "scope" in newer releases.
Also, request-related datetime values are timezone-aware since werkzeug 2.0.0.
https://werkzeug.palletsprojects.com/en/2.0.x/changes/#version-2-0-0