### PR TITLE
setup: bump `webargs` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     invenio-logging[sentry_sdk]>=2.1.0
     itsdangerous>=1.1,<2.1
     marshmallow>=2.15.2
-    webargs>=5.5.0,<6.0.0
+    webargs>=5.5.0,<9.0.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
Allow newer versions of the `webargs` dependency to get rid of some deprecation warnings