### PR TITLE
Pin marshmallow to <4.0.0 and release v2.0.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
 Changes
 =======
 
+Version v2.0.3 (released 2025-04-17)
+
+- installation: pin marshmallow to <4.0.0
+
 Version v2.0.2 (released 2025-02-24)
 
 - fix: copyright headers

--- a/invenio_rest/__init__.py
+++ b/invenio_rest/__init__.py
@@ -196,6 +196,6 @@ from .csrf import csrf
 from .ext import InvenioREST
 from .views import ContentNegotiatedMethodView
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 __all__ = ("__version__", "csrf", "InvenioREST", "ContentNegotiatedMethodView")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2024 CERN.
+# Copyright (C) 2015-2025 CERN.
 # Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     invenio-base>=2.0.0,<3.0.0
     invenio-logging>=4.0.0,<5.0.0
     itsdangerous>=2.2.0
-    marshmallow>=2.15.2
+    marshmallow>=2.15.2,<4.0.0
     webargs>=5.5.0,<6.0.0
 
 [options.extras_require]


### PR DESCRIPTION
- **installation: pin marshmallow to <4.0.0**
  

- **📦 release: v2.0.3**
  