### PR TITLE
Maint 1.5.2 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,7 +13,9 @@ on:
   push:
     branches: master
   pull_request:
-    branches: master
+    branches:
+      - master
+      - "maint-**"
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 3 * * 6'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v1.5.2 (released 2025-06-25)
+
+- csrf: more flexible handling of APP_ALLOWED_HOSTS
+    * Fixes a bug where the CSRF middleware would crash if `APP_ALLOWED_HOSTS` was set to `None`.
+
 Version v1.5.1 (released 2025-04-29)
 
 - setup: pin dependency marshmallow

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,17 @@
     This file is part of Invenio.
     Copyright (C) 2015-2020 CERN.
     Copyright (C) 2022 Northwestern University.
-    Copyright (C) 2024 Graz University of Technology.
+    Copyright (C) 2024-2025 Graz University of Technology.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 Changes
 =======
+
+Version v1.5.1 (released 2025-04-29)
+
+- setup: pin dependency marshmallow
 
 Version v1.5.0 (released 2024-12-02)
 

--- a/invenio_rest/__init__.py
+++ b/invenio_rest/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -196,6 +196,6 @@ from .csrf import csrf
 from .ext import InvenioREST
 from .views import ContentNegotiatedMethodView
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 __all__ = ("__version__", "csrf", "InvenioREST", "ContentNegotiatedMethodView")

--- a/invenio_rest/__init__.py
+++ b/invenio_rest/__init__.py
@@ -196,6 +196,6 @@ from .csrf import csrf
 from .ext import InvenioREST
 from .views import ContentNegotiatedMethodView
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 __all__ = ("__version__", "csrf", "InvenioREST", "ContentNegotiatedMethodView")

--- a/invenio_rest/csrf.py
+++ b/invenio_rest/csrf.py
@@ -172,12 +172,13 @@ def csrf_validate():
         if not _is_referer_secure(referer):
             return _abort400(REASON_INSECURE_REFERER)
 
-        is_hostname_allowed = referer.hostname in current_app.config.get(
-            "APP_ALLOWED_HOSTS"
-        )
-        if not is_hostname_allowed:
-            reason = REASON_BAD_REFERER % referer.geturl()
-            return _abort400(reason)
+        # Handle APP_ALLOWED_HOSTS is None
+        allowed_hosts = current_app.config.get("APP_ALLOWED_HOSTS")
+        if allowed_hosts is not None:
+            is_hostname_allowed = referer.hostname in allowed_hosts
+            if not is_hostname_allowed:
+                reason = REASON_BAD_REFERER % referer.geturl()
+                return _abort400(reason)
 
     decoded_request_csrf_token = _decode_csrf(request_csrf_token)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -31,7 +31,7 @@ install_requires =
     invenio-base>=1.2.5,<2.0.0
     invenio-logging>=2.1.0,<3.0.0
     itsdangerous>=1.1.0
-    marshmallow>=2.15.2
+    marshmallow>=2.15.2,<4.0.0
     webargs>=5.5.0,<6.0.0
 
 [options.extras_require]


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Add support for APP_ALLOWED_HOSTS = None. While this is not advised in production environments, there are situations with reverse-proxies where this might be needed. crsf_validate is currently failing in this scenario. This fix in the maint-1.x branch is for InvenioRDM v12, as v13 uses TRUSTED_HOSTS instead of APP_ALLOWED_HOSTS

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ x I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
