### PR TITLE
fix(serializer): inherit context_schema in nested BaseSchema calls

### DIFF
--- a/invenio_rest/serializer.py
+++ b/invenio_rest/serializer.py
@@ -66,45 +66,54 @@ def result_wrapper(result):
     return result
 
 
+def _init_context(kwargs):
+    """Init context_schema from kwargs only if context exists.
+
+    Nested calls can't provide context, therefor they inherit the open context.
+    """
+    if "context" in kwargs:
+        context = kwargs.pop("context")
+        token = context_schema.set(context)
+        return lambda: context_schema.reset(token)
+    else:
+        return lambda: None
+
+
 class BaseSchema(Schema):
     """Base schema for all serializations."""
 
     def dump(self, obj, *args, **kwargs):
         """Wrap dump result for backward compatibility."""
-        context = kwargs.pop("context", {})
-        token = context_schema.set(context)
+        clear_context = _init_context(kwargs)
         try:
             result = super(BaseSchema, self).dump(obj, **kwargs)
             return result_wrapper(result)
         finally:
-            context_schema.reset(token)
+            clear_context()
 
     def dumps(self, obj, *args, **kwargs):
         """Wrap dumps result for backward compatibility."""
-        context = kwargs.pop("context", {})
-        token = context_schema.set(context)
+        clear_context = _init_context(kwargs)
         try:
             result = super(BaseSchema, self).dumps(obj, *args, **kwargs)
             return result_wrapper(result)
         finally:
-            context_schema.reset(token)
+            clear_context()
 
     def load(self, obj, *args, **kwargs):
         """Wrap load result for backward compatibility."""
-        context = kwargs.pop("context", {})
-        token = context_schema.set(context)
+        clear_context = _init_context(kwargs)
         try:
             result = super(BaseSchema, self).load(obj, *args, **kwargs)
             return result_wrapper(result)
         finally:
-            context_schema.reset(token)
+            clear_context()
 
     def loads(self, obj, *args, **kwargs):
         """Wrap loads result for backward compatibility."""
-        context = kwargs.pop("context", {})
-        token = context_schema.set(context)
+        clear_context = _init_context(kwargs)
         try:
             result = super(BaseSchema, self).loads(obj, *args, **kwargs)
             return result_wrapper(result)
         finally:
-            context_schema.reset(token)
+            clear_context()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, print_function
 from collections import namedtuple
 
 from marshmallow import fields
+from marshmallow_utils.context import context_schema
 
 from invenio_rest.serializer import BaseSchema, result_wrapper
 
@@ -48,3 +49,24 @@ def test_marshmallow_compatibility():
     assert wrapped == tuple_result
     assert isinstance(wrapped, tuple)
     assert tuple_result.data == dict_result
+
+
+def test_nested_schema_inherits_context():
+    """Nested BaseSchema must not overwrite the parent's context_schema."""
+
+    class Inner(BaseSchema):
+        name = fields.Method("get_name")
+
+        def get_name(self, obj):
+            return context_schema.get({}).get("name", "MISSING")
+
+    class Outer(BaseSchema):
+        inner = fields.Nested(Inner)
+        name = fields.Method("get_name")
+
+        def get_name(self, obj):
+            return context_schema.get({}).get("name", "MISSING")
+
+    result = Outer().dump({"inner": {}}, context={"name": "ctx"})
+    assert result["name"] == "ctx"
+    assert result["inner"]["name"] == "ctx"


### PR DESCRIPTION
### Description

BaseSchema.dump (and dumps/load/loads) unconditionally called context_schema.set({}), which erased the parent context on every recursive call Marshmallow makes for fields.Nested. Any field reading context_schema inside a nested schema silently lost its context.

Now context_schema is only set when the caller explicitly passes context=..., or when no context is live at all (safe default for a bare top-level call). Nested calls without a context= kwarg inherit the parent's ContextVar value unchanged.

### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).