### PR TITLE
fix(views): check_etag() now handles weak ETags in If-Match

### DIFF
--- a/invenio_rest/views.py
+++ b/invenio_rest/views.py
@@ -281,7 +281,7 @@ class ContentNegotiatedMethodView(MethodView):
         # bool(:py:class:`werkzeug.datastructures.ETags`) is not consistent
         # in Python 3. bool(Etags()) == True even though it is empty.
         if (
-            len(request.if_match.as_set(include_weak=weak)) > 0
+            len(request.if_match.as_set(include_weak=True)) > 0
             or request.if_match.star_tag
         ):
             contains_etag = (
@@ -289,10 +289,14 @@ class ContentNegotiatedMethodView(MethodView):
                 if weak
                 else request.if_match.contains(etag)
             )
+            # Proxies (e.g. nginx with gzip) downgrade strong ETags to weak
+            # ones (RFC 7232 §2.3); accept weak matches as a fallback.
+            if not contains_etag:
+                contains_etag = request.if_match.contains_weak(etag)
             if not contains_etag and "*" not in request.if_match:
                 abort(412)
         if (
-            len(request.if_none_match.as_set(include_weak=weak)) > 0
+            len(request.if_none_match.as_set(include_weak=True)) > 0
             or request.if_none_match.star_tag
         ):
             contains_etag = (
@@ -300,6 +304,10 @@ class ContentNegotiatedMethodView(MethodView):
                 if weak
                 else request.if_none_match.contains(etag)
             )
+            # Proxies (e.g. nginx with gzip) downgrade strong ETags to weak
+            # ones (RFC 7232 §2.3); accept weak matches as a fallback.
+            if not contains_etag:
+                contains_etag = request.if_none_match.contains_weak(etag)
             if contains_etag or "*" in request.if_none_match:
                 if request.method in ("GET", "HEAD"):
                     raise SameContentException(etag)

--- a/tests/test_invenio_rest.py
+++ b/tests/test_invenio_rest.py
@@ -753,6 +753,22 @@ def _subtest_content_negotiation_method_view(app, content_negotiated_class, para
             )
             check_normal_response(res, method)
 
+        # check matching weak If-None-Match against strong ETag (nginx gzip downgrade)
+        # GET/HEAD must return 304; write methods must return 412.
+        headers = [("Accept", "application/json"), ("If-None-Match", 'W/"abc"')]
+        for method in read_methods:
+            res = method("/objects/1", headers=headers)
+            check_304_response(res)
+        for method in write_methods:
+            res = method("/objects/1", headers=headers)
+            assert res.status_code == 412
+
+        # check non-matching weak If-None-Match against strong ETag (nginx gzip downgrade)
+        headers = [("Accept", "application/json"), ("If-None-Match", 'W/"xyz"')]
+        for method in all_methods:
+            res = method("/objects/1", headers=headers)
+            check_normal_response(res, method)
+
         # check matching If-Match
         headers = [("Accept", "application/json"), ("If-Match", '"abc", "def"')]
         for method in all_methods:
@@ -781,6 +797,20 @@ def _subtest_content_negotiation_method_view(app, content_negotiated_class, para
             res = method(
                 "/objects/1", headers=headers, query_string=query_string_weak_etags
             )
+            assert res.status_code == 412
+
+        # check matching weak If-Match against strong ETag (nginx gzip downgrade)
+        # When a proxy applies gzip it converts "abc" → W/"abc"; the check must
+        # still pass (weak=False, but the incoming If-Match carries a weak ETag).
+        headers = [("Accept", "application/json"), ("If-Match", 'W/"abc"')]
+        for method in all_methods:
+            res = method("/objects/1", headers=headers)
+            check_normal_response(res, method)
+
+        # check non-matching weak If-Match against strong ETag (nginx gzip downgrade)
+        headers = [("Accept", "application/json"), ("If-Match", 'W/"xyz"')]
+        for method in all_methods:
+            res = method("/objects/1", headers=headers)
             assert res.status_code == 412
 
         # check If-Modified-Since


### PR DESCRIPTION
When nginx (or any gzip proxy) compresses a response it downgrades a
strong ETag "N" to W/"N" (RFC 7232 §2.3). Werkzeug parses W/"N" as a
weak ETag, and the previous code used as_set(include_weak=False) to
detect whether If-Match contained any ETags -- returning an empty set
for a purely-weak header and silently skipping the precondition check.
Any PUT therefore succeeded with 200 regardless of the If-Match value.

Fix: always pass include_weak=True when probing for ETags in If-Match,
and fall back to a weak comparison when the strict comparison fails.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
